### PR TITLE
Bump solana-verify version, update yarn.lock

### DIFF
--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      SOLANA_VERIFY_VERSION: "0.4.1"
+      SOLANA_VERIFY_VERSION: "0.5.0"
     outputs:
       buffer: ${{ steps.program-buffer.outputs.buffer }}
       idl_buffer: ${{ steps.idl-buffer.outputs.buffer }}

--- a/.github/workflows/verified-build.yaml
+++ b/.github/workflows/verified-build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      SOLANA_VERIFY_VERSION: "0.4.1"
+      SOLANA_VERIFY_VERSION: "0.5.0"
     steps:
       - uses: actions/checkout@v4
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@
   resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.31.1.tgz#d635cbac2533973ae6bfb5d3ba1de89ce5aece2d"
   integrity sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==
 
-"@coral-xyz/anchor@0.31.1":
+"@coral-xyz/anchor@=0.31.1":
   version "0.31.1"
   resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.31.1.tgz#0fdeebf45a3cb2e47e8ebbb815ca98542152962c"
   integrity sha512-QUqpoEK+gi2S6nlYc2atgT2r41TT3caWr/cPUEL8n8Md9437trZ68STknq897b82p5mW0XrTBNOzRbmIRJtfsA==
@@ -210,7 +210,7 @@
   dependencies:
     "@solana/codecs" "2.0.0-rc.1"
 
-"@solana/spl-token@^0.4.13":
+"@solana/spl-token@=0.4.13":
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.4.13.tgz#8f65c3c2b315e1a00a91b8d0f60922c6eb71de62"
   integrity sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==
@@ -221,7 +221,7 @@
     "@solana/spl-token-metadata" "^0.1.6"
     buffer "^6.0.3"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.98.4":
+"@solana/web3.js@=1.98.4", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.69.0":
   version "1.98.4"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.98.4.tgz#df51d78be9d865181ec5138b4e699d48e6895bbe"
   integrity sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==


### PR DESCRIPTION
## Problem

The `verified-build` workflow fails before any compilation with `Error: parse error: invalid Cargo.lock format version: 4`. `solana-verify` parses `Cargo.lock` on startup, and the pinned `0.4.1` depends on `cargo-lock = "9.0.0"`, which predates v4 lockfile support. Our `Cargo.lock` is `version = 4` (cargo's default since Rust 1.83), so the tool rejects it.

The `cargo-lock` crate only gained v4 support in 10.0.0. `solana-verify 0.5.0` depends on `cargo-lock = "10.1.0"`, which is exactly why local builds on 0.5.0 already pass.

## Fix

Bump `SOLANA_VERIFY_VERSION` from `0.4.1` to `0.5.0` in `verified-build.yaml` and `reusable-build.yaml`. This only upgrades the CLI orchestrating the build — the Solana 2.3.0 image and resulting `.so` (and its verified hash) are unchanged.

Note: downgrading `Cargo.lock` to v3 would also silence the error but is the wrong fix — the toolchain is fine, local cargo would keep regenerating v4, and it hides the stale-tooling root cause.

## Sources

- [cargo-lock CHANGELOG — v10.0.0 "V4 lockfile support (#1206)", 2024-10-15](https://github.com/rustsec/rustsec/blob/main/cargo-lock/CHANGELOG.md)
- [solana-verifiable-build](https://github.com/solana-foundation/solana-verifiable-build) — `cargo-lock = "9.0.0"` at v0.4.1 vs `cargo-lock = "10.1.0"` at v0.5.0
- [rust-lang/cargo #15306](https://github.com/rust-lang/cargo/issues/15306) — the separate toolchain-layer flavor of the same error