### PR TITLE
Add `Ratio` migration strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ withdraw_amount = floor(deposit_amount * numerator / denominator)
 - `Ratio { numerator: 1, denominator: 2 }`: 1 out per 2 in (e.g., 100 → 50)
 - `Ratio { numerator: 1, denominator: 1 }`: 1:1 ratio (e.g., 100 → 100)
 
-Both `numerator` and `denominator` must be non-zero. Like `Fixed`, this operates on **raw base units** and is not decimal-aware: if the mints have different decimals, fold the `10^(decimals_to - decimals_from)` factor into the ratio (see the worked example in `RATIO_STRATEGY.md`). Division floors; the residue stays in the vault.
+Both `numerator` and `denominator` must be non-zero. Like `Fixed`, this operates on **raw base units** and is not decimal-aware: if the mints have different decimals, fold the `10^(decimals_to - decimals_from)` factor into the ratio. Division floors; the residue stays in the vault.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A Solana program for migrating tokens from one mint to another using configurabl
 
 ## Overview
 
-This Anchor program enables users to migrate their tokens from an old token mint to a new token mint based on predefined migration strategies. The program supports two migration strategies:
+This Anchor program enables users to migrate their tokens from an old token mint to a new token mint based on predefined migration strategies. The program supports three migration strategies:
 
 - **ProRata**: Calculates withdrawal amounts based on proportional supply of both tokens
 - **Fixed**: Scales the deposited amount up or down by 10^e for decimal redenomination
+- **Ratio**: Applies a fixed rational rate `numerator / denominator` to the deposited amount
 
 ## Quick Start
 
@@ -82,6 +83,17 @@ Scales amounts by powers of 10:
 - `Fixed(1)`: Multiply by 10 (e.g., 100 → 1000)
 - `Fixed(-1)`: Divide by 10 (e.g., 100 → 10)
 - `Fixed(0)`: 1:1 ratio (e.g., 100 → 100)
+
+### Ratio Strategy
+Applies a fixed rational conversion rate, ignoring token supply:
+```
+withdraw_amount = floor(deposit_amount * numerator / denominator)
+```
+- `Ratio { numerator: 3, denominator: 2 }`: 3 out per 2 in (e.g., 100 → 150)
+- `Ratio { numerator: 1, denominator: 2 }`: 1 out per 2 in (e.g., 100 → 50)
+- `Ratio { numerator: 1, denominator: 1 }`: 1:1 ratio (e.g., 100 → 100)
+
+Both `numerator` and `denominator` must be non-zero. Like `Fixed`, this operates on **raw base units** and is not decimal-aware: if the mints have different decimals, fold the `10^(decimals_to - decimals_from)` factor into the ratio (see the worked example in `RATIO_STRATEGY.md`). Division floors; the residue stays in the vault.
 
 ## Security
 

--- a/programs/token-migrator/Cargo.toml
+++ b/programs/token-migrator/Cargo.toml
@@ -22,3 +22,9 @@ anchor-lang = { version = "0.31.1", features = ["event-cpi"] }
 anchor-spl = "0.31.1"
 solana-security-txt = "1.1.1"
 
+[lints.rust]
+# Allow unexpected cfg flags in the codebase (silence rust-analyzer warning noise)
+unexpected_cfgs = { level = "allow", check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("custom-heap", "custom-panic", "anchor-debug"))',
+] }

--- a/programs/token-migrator/src/errors.rs
+++ b/programs/token-migrator/src/errors.rs
@@ -4,4 +4,6 @@ use anchor_lang::prelude::*;
 pub enum MigratorError {
     #[msg("Fixed strategy exponent out of range (|e| must be <= 19)")]
     ExponentOutOfRange,
+    #[msg("Ratio numerator and denominator must both be non-zero")]
+    InvalidRatio,
 }

--- a/programs/token-migrator/src/state.rs
+++ b/programs/token-migrator/src/state.rs
@@ -62,7 +62,7 @@ impl Strategy {
                 .saturating_div(supply_from.into())
                 .try_into()
                 .map_err(|_| ProgramError::ArithmeticOverflow)?,
-            Strategy::Fixed { e} => {
+            Strategy::Fixed { e } => {
                 if e == 0 {
                     amount
                 } else if e < 0 {

--- a/programs/token-migrator/src/state.rs
+++ b/programs/token-migrator/src/state.rs
@@ -5,13 +5,15 @@ use crate::errors::MigratorError;
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq, InitSpace)]
 /// # Strategy
 ///
-/// Defines the strategy by which we perform a migration. There are two cases:
+/// Defines the strategy by which we perform a migration. There are three cases:
 ///
 /// `ProRata` - Calculates a `withdraw_amount` based upon pro-rated supply of both tokens.
 /// `Fixed(i8)` - Calculates `withdraw_amount` by scaling the `amount` deposited up or down by `10^e`. Useful for decimal redenomination.
+/// `Ratio { numerator, denominator }` - Calculates `withdraw_amount = floor(amount * numerator / denominator)`, a fixed rational rate that ignores supply.
 pub enum Strategy {
     ProRata,
     Fixed { e: i8 },
+    Ratio { numerator: u64, denominator: u64 },
 }
 
 /// Maximum magnitude of the `Fixed` exponent. `10^19` is the largest power of
@@ -25,14 +27,25 @@ impl Strategy {
     /// Ensures the strategy parameters are within safe bounds before the vault
     /// is persisted. For `Fixed`, the exponent magnitude must be
     /// `<= MAX_FIXED_EXPONENT` so the `10u64.pow(|e|)` scaling in
-    /// `withdraw_amount` cannot overflow. `ProRata` carries no parameters and is
-    /// always valid.
+    /// `withdraw_amount` cannot overflow. For `Ratio`, both `numerator` and
+    /// `denominator` must be non-zero: a zero denominator would divide by zero,
+    /// and a zero numerator would make every migration round to zero output.
+    /// `ProRata` carries no parameters and is always valid.
     pub fn validate(&self) -> Result<()> {
         if let Strategy::Fixed { e } = self {
             require!(
                 e.unsigned_abs() <= MAX_FIXED_EXPONENT,
                 MigratorError::ExponentOutOfRange
             );
+        }
+
+        if let Strategy::Ratio {
+            numerator,
+            denominator,
+        } = self
+        {
+            require!(*denominator > 0, MigratorError::InvalidRatio);
+            require!(*numerator > 0, MigratorError::InvalidRatio);
         }
 
         Ok(())
@@ -64,6 +77,16 @@ impl Strategy {
                         .ok_or(ProgramError::ArithmeticOverflow)?
                 }
             }
+            Strategy::Ratio {
+                numerator,
+                denominator,
+            } => u128::from(amount)
+                .checked_mul(u128::from(numerator))
+                .ok_or(ProgramError::ArithmeticOverflow)?
+                .checked_div(u128::from(denominator))
+                .ok_or(ProgramError::ArithmeticOverflow)?
+                .try_into()
+                .map_err(|_| ProgramError::ArithmeticOverflow)?,
         };
 
         // Ensure withdraw amount is not zero
@@ -138,5 +161,114 @@ mod tests {
         assert!(Strategy::Fixed { e: -20 }.validate().is_err());
         assert!(Strategy::Fixed { e: i8::MAX }.validate().is_err());
         assert!(Strategy::Fixed { e: i8::MIN }.validate().is_err());
+    }
+
+    #[test]
+    fn test_ratio_identity() {
+        let strategy = Strategy::Ratio {
+            numerator: 1,
+            denominator: 1,
+        };
+        assert_eq!(strategy.withdraw_amount(10, 0, 0).unwrap(), 10);
+    }
+
+    #[test]
+    fn test_ratio_up() {
+        let strategy = Strategy::Ratio {
+            numerator: 3,
+            denominator: 2,
+        };
+        assert_eq!(strategy.withdraw_amount(100, 0, 0).unwrap(), 150);
+    }
+
+    #[test]
+    fn test_ratio_down() {
+        let strategy = Strategy::Ratio {
+            numerator: 1,
+            denominator: 2,
+        };
+        assert_eq!(strategy.withdraw_amount(100, 0, 0).unwrap(), 50);
+    }
+
+    #[test]
+    fn test_ratio_floor() {
+        // 100 * 1 / 3 = 33.33 -> 33 (floor)
+        let strategy = Strategy::Ratio {
+            numerator: 1,
+            denominator: 3,
+        };
+        assert_eq!(strategy.withdraw_amount(100, 0, 0).unwrap(), 33);
+    }
+
+    #[test]
+    fn test_ratio_zero_output_err() {
+        // 100 * 1 / 1000 = 0 -> rejected by the zero-output guard
+        let strategy = Strategy::Ratio {
+            numerator: 1,
+            denominator: 1000,
+        };
+        assert!(strategy.withdraw_amount(100, 0, 0).is_err());
+    }
+
+    #[test]
+    fn test_ratio_large_no_u128_overflow() {
+        // u64::MAX * u64::MAX fits in u128; / u64::MAX == u64::MAX. Must not panic.
+        let strategy = Strategy::Ratio {
+            numerator: u64::MAX,
+            denominator: u64::MAX,
+        };
+        assert_eq!(strategy.withdraw_amount(u64::MAX, 0, 0).unwrap(), u64::MAX);
+    }
+
+    #[test]
+    fn test_ratio_result_exceeds_u64_err() {
+        // 2 * u64::MAX / 1 overflows u64 on the final try_into -> Err
+        let strategy = Strategy::Ratio {
+            numerator: u64::MAX,
+            denominator: 1,
+        };
+        assert!(strategy.withdraw_amount(2, 0, 0).is_err());
+    }
+
+    #[test]
+    fn test_validate_ratio_ok() {
+        assert!(Strategy::Ratio {
+            numerator: 1,
+            denominator: 1
+        }
+        .validate()
+        .is_ok());
+        assert!(Strategy::Ratio {
+            numerator: 3,
+            denominator: 2
+        }
+        .validate()
+        .is_ok());
+        assert!(Strategy::Ratio {
+            numerator: u64::MAX,
+            denominator: u64::MAX
+        }
+        .validate()
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_ratio_zero_denominator_err() {
+        assert!(Strategy::Ratio {
+            numerator: 1,
+            denominator: 0
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn test_validate_ratio_zero_numerator_err() {
+        assert!(Strategy::Ratio {
+            numerator: 0,
+            denominator: 1
+        }
+        .validate()
+        .is_err());
     }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metadaoproject/token-migrator",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/sdk/src/v0.1/TokenMigratorClient.ts
+++ b/sdk/src/v0.1/TokenMigratorClient.ts
@@ -115,6 +115,10 @@ export class TokenMigratorClient {
     return { fixed: { e } };
   }
 
+  createRatioStrategy(numerator: BN, denominator: BN): Strategy {
+    return { ratio: { numerator, denominator } };
+  }
+
   /**
    * Initialize a new token migration vault. Permissionless: anyone can create a
    * vault and becomes its `admin`. The vault PDA is seeded by `admin`, so the
@@ -133,7 +137,7 @@ export class TokenMigratorClient {
    *
    * @param mintFrom - Source mint
    * @param mintTo - Destination mint
-   * @param strategy - { proRata: {} } or { fixed: { e } }
+   * @param strategy - { proRata: {} }, { fixed: { e } }, or { ratio: { numerator, denominator } }
    * @param admin - Vault admin/signer; defaults to this.wallet.publicKey
    * @param payer - Funds the vault ATA accounts creation; defaults to `admin`
    */
@@ -245,6 +249,7 @@ export class TokenMigratorClient {
    * Calculate expected output amount
    * - ProRata: out = amount * mintToSupply / mintFromSupply
    * - Fixed:   out = amount * 10^e  (or / 10^|e| if e < 0)
+   * - Ratio:   out = amount * numerator / denominator
    */
   calculateMigrationAmount(
     vault: Vault,
@@ -264,6 +269,11 @@ export class TokenMigratorClient {
       } else {
         return amount.div(new BN(10).pow(new BN(-e)));
       }
+    } else if ("ratio" in vault.strategy) {
+      const { numerator, denominator } = vault.strategy.ratio;
+      // BN.div truncates toward zero == floor for non-negative operands,
+      // matching the on-chain u128 muldiv floor.
+      return amount.mul(numerator).div(denominator);
     }
     throw new Error("Unknown strategy type");
   }

--- a/sdk/src/v0.1/idl/token_migrator.json
+++ b/sdk/src/v0.1/idl/token_migrator.json
@@ -569,6 +569,11 @@
       "code": 6000,
       "name": "ExponentOutOfRange",
       "msg": "Fixed strategy exponent out of range (|e| must be <= 19)"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidRatio",
+      "msg": "Ratio numerator and denominator must both be non-zero"
     }
   ],
   "types": [
@@ -605,10 +610,11 @@
       "docs": [
         "# Strategy",
         "",
-        "Defines the strategy by which we perform a migration. There are two cases:",
+        "Defines the strategy by which we perform a migration. There are three cases:",
         "",
         "`ProRata` - Calculates a `withdraw_amount` based upon pro-rated supply of both tokens.",
-        "`Fixed(i8)` - Calculates `withdraw_amount` by scaling the `amount` deposited up or down by `10^e`. Useful for decimal redenomination."
+        "`Fixed(i8)` - Calculates `withdraw_amount` by scaling the `amount` deposited up or down by `10^e`. Useful for decimal redenomination.",
+        "`Ratio { numerator, denominator }` - Calculates `withdraw_amount = floor(amount * numerator / denominator)`, a fixed rational rate that ignores supply."
       ],
       "type": {
         "kind": "enum",
@@ -622,6 +628,19 @@
               {
                 "name": "e",
                 "type": "i8"
+              }
+            ]
+          },
+          {
+            "name": "Ratio",
+            "fields": [
+              {
+                "name": "numerator",
+                "type": "u64"
+              },
+              {
+                "name": "denominator",
+                "type": "u64"
               }
             ]
           }

--- a/sdk/src/v0.1/types/index.ts
+++ b/sdk/src/v0.1/types/index.ts
@@ -16,7 +16,10 @@ export type MigrateEvent = IdlEvents<TokenMigratorProgram>["migrateEvent"];
 export type TokenMigrationEvents = MigrateEvent;
 
 // Strategy enum type
-export type Strategy = { proRata: {} } | { fixed: { e: number } };
+export type Strategy =
+  | { proRata: {} }
+  | { fixed: { e: number } }
+  | { ratio: { numerator: BN; denominator: BN } };
 
 import { IdlEvents } from "@coral-xyz/anchor";
 // Re-export PublicKey and BN for convenience

--- a/sdk/src/v0.1/types/token_migrator.ts
+++ b/sdk/src/v0.1/types/token_migrator.ts
@@ -556,6 +556,11 @@ export type TokenMigrator = {
       name: "exponentOutOfRange";
       msg: "Fixed strategy exponent out of range (|e| must be <= 19)";
     },
+    {
+      code: 6001;
+      name: "invalidRatio";
+      msg: "Ratio numerator and denominator must both be non-zero";
+    },
   ];
   types: [
     {
@@ -591,10 +596,11 @@ export type TokenMigrator = {
       docs: [
         "# Strategy",
         "",
-        "Defines the strategy by which we perform a migration. There are two cases:",
+        "Defines the strategy by which we perform a migration. There are three cases:",
         "",
         "`ProRata` - Calculates a `withdraw_amount` based upon pro-rated supply of both tokens.",
         "`Fixed(i8)` - Calculates `withdraw_amount` by scaling the `amount` deposited up or down by `10^e`. Useful for decimal redenomination.",
+        "`Ratio { numerator, denominator }` - Calculates `withdraw_amount = floor(amount * numerator / denominator)`, a fixed rational rate that ignores supply.",
       ];
       type: {
         kind: "enum";
@@ -608,6 +614,19 @@ export type TokenMigrator = {
               {
                 name: "e";
                 type: "i8";
+              },
+            ];
+          },
+          {
+            name: "ratio";
+            fields: [
+              {
+                name: "numerator";
+                type: "u64";
+              },
+              {
+                name: "denominator";
+                type: "u64";
               },
             ];
           },

--- a/tests/token-migrator.ts
+++ b/tests/token-migrator.ts
@@ -199,4 +199,146 @@ describe("token-migrator", () => {
         .then(log);
     });
   });
+
+  describe("Ratio Strategy", async () => {
+    // Fresh mints => a distinct vault PDA, reusing the same admin/user.
+    const ratioMintFromKeypair = Keypair.generate();
+    const ratioMintToKeypair = Keypair.generate();
+    const ratioMintFrom = ratioMintFromKeypair.publicKey;
+    const ratioMintTo = ratioMintToKeypair.publicKey;
+
+    const ratioVault = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("vault"),
+        admin.toBuffer(),
+        ratioMintFrom.toBuffer(),
+        ratioMintTo.toBuffer(),
+      ],
+      program.programId,
+    )[0];
+
+    const [rUserFromTa, rUserToTa, rVaultFromAta, rVaultToAta] = [
+      getAssociatedTokenAddressSync(ratioMintFrom, user, false),
+      getAssociatedTokenAddressSync(ratioMintTo, user, false),
+      getAssociatedTokenAddressSync(ratioMintFrom, ratioVault, true),
+      getAssociatedTokenAddressSync(ratioMintTo, ratioVault, true),
+    ];
+
+    const ratioAccounts = {
+      admin,
+      mintFrom: ratioMintFrom,
+      mintTo: ratioMintTo,
+      user,
+      userFromTa: rUserFromTa,
+      userToTa: rUserToTa,
+      vault: ratioVault,
+      vaultFromAta: rVaultFromAta,
+      vaultToAta: rVaultToAta,
+      tokenProgram,
+      systemProgram,
+      eventAuthority,
+      program: program.programId,
+    };
+
+    const DEPOSIT = new BN(100_000_000);
+    const NUMERATOR = new BN(3);
+    const DENOMINATOR = new BN(2);
+    // floor(100_000_000 * 3 / 2) = 150_000_000
+    const EXPECTED_OUT = DEPOSIT.mul(NUMERATOR).div(DENOMINATOR);
+
+    it("Sets up fresh mints and funds the ratio user's `from` ATA.", async () => {
+      const lamports = await getMinimumBalanceForRentExemptMint(connection);
+      const tx = new Transaction();
+      tx.instructions = [
+        ...[ratioMintFrom, ratioMintTo].flatMap((mint) => [
+          SystemProgram.createAccount({
+            fromPubkey: provider.publicKey,
+            newAccountPubkey: mint,
+            lamports,
+            space: MINT_SIZE,
+            programId: tokenProgram,
+          }),
+          createInitializeMint2Instruction(mint, 6, provider.publicKey!, null),
+        ]),
+        createAssociatedTokenAccountIdempotentInstruction(
+          provider.publicKey,
+          rUserFromTa,
+          user,
+          ratioMintFrom,
+        ),
+        createMintToInstruction(
+          ratioMintFrom,
+          rUserFromTa,
+          provider.publicKey!,
+          1e9,
+        ),
+      ];
+
+      await provider
+        .sendAndConfirm(tx, [ratioMintFromKeypair, ratioMintToKeypair])
+        .then(log);
+    });
+
+    it("Initializes a Ratio { 3, 2 } vault and funds `vaultToAta`.", async () => {
+      await program.methods
+        .initialize(ratioMintFrom, ratioMintTo, {
+          ratio: { numerator: NUMERATOR, denominator: DENOMINATOR },
+        })
+        .accountsStrict({
+          ...ratioAccounts,
+        })
+        .preInstructions([
+          createAssociatedTokenAccountIdempotentInstruction(
+            admin,
+            rVaultFromAta,
+            ratioVault,
+            ratioMintFrom,
+          ),
+          createAssociatedTokenAccountIdempotentInstruction(
+            admin,
+            rVaultToAta,
+            ratioVault,
+            ratioMintTo,
+          ),
+          // Fund the `to` vault above EXPECTED_OUT (3:2 pays out more than it takes in).
+          createMintToInstruction(
+            ratioMintTo,
+            rVaultToAta,
+            provider.publicKey!,
+            1e9,
+          ),
+        ])
+        .signers([adminKeypair])
+        .rpc()
+        .then(confirm)
+        .then(log);
+    });
+
+    it("Migrates and receives floor(amount * 3 / 2) of `mintTo`.", async () => {
+      await program.methods
+        .migrate(DEPOSIT)
+        .preInstructions([
+          createAssociatedTokenAccountIdempotentInstruction(
+            user,
+            rUserToTa,
+            user,
+            ratioMintTo,
+          ),
+        ])
+        .accountsStrict({
+          ...ratioAccounts,
+        })
+        .signers([userKeypair])
+        .rpc()
+        .then(confirm)
+        .then(log);
+
+      const bal = await connection.getTokenAccountBalance(rUserToTa);
+      if (bal.value.amount !== EXPECTED_OUT.toString()) {
+        throw new Error(
+          `expected ${EXPECTED_OUT.toString()} got ${bal.value.amount}`,
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
Adds a third migration strategy, `Ratio { numerator, denominator }`, that computes `withdraw_amount = floor(amount * numerator / denominator)`. It's a fixed-rate strategy (ignores token supply, like `Fixed`) that generalizes `Fixed` beyond powers of ten — e.g. "0.15 USDC per TOK".

## What changed

- **Program**: new `Ratio { numerator: u64, denominator: u64 }` variant appended last in the `Strategy` enum (discriminant 2); `validate()` rejects a zero numerator or denominator with a new `InvalidRatio` error; `withdraw_amount()` adds a checked `u128` muldiv arm (floors, narrows to `u64`).
- **SDK**: extended the `Strategy` union, added a `createRatioStrategy(numerator, denominator)` helper and a `ratio` branch in `calculateMigrationAmount`; IDL/types regenerated.
- **Tests**: 10 Rust unit tests (rates, floor, overflow-safety, zero/oversized guards, validation) and a 3-step TS integration test asserting exact output.
- **Docs**: README "Ratio Strategy" section; full design + decisions in `RATIO_STRATEGY.md`.

## Testing

- `cargo test -p token-migrator` — 19 passing (10 new).
- `anchor test` — 6 passing; migrate receives exactly `floor(100M * 3/2) = 150M`.
- `sdk` build (`tsc`) clean.

## Backward compatibility

The variant is appended last, so `ProRata`/`Fixed` Borsh tags are unchanged and existing on-chain vaults still deserialize (new vaults grow 100 → 115 bytes; reads aren't length-checked against `INIT_SPACE`). No account migration or realloc needed.